### PR TITLE
複数の環境にデプロイ出来るように設定を追加

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,8 +25,9 @@ provider:
     KIMONO_APP_FRONTEND_URL: ${env:KIMONO_APP_FRONTEND_URL}
 
 custom:
-  defaultStage: stg
+  defaultStage: local
   profiles:
+    prod: kimono-app-prod
     stg: kimono-app-stg
     local: kimono-app-stg
   prune:

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,7 @@ custom:
   defaultStage: stg
   profiles:
     stg: kimono-app-stg
+    local: kimono-app-stg
   prune:
     automatic: true
     number: 3


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-cognito-lambda/issues/9

# Doneの定義
- 複数のstageにデプロイ出来るようになっている事

# 変更点概要
`serverless.yml` の `profiles` に環境の設定を追加。

また `defaultStage` の設定を `local` に変更。

理由としては、万が一、間違えてデプロイして環境が壊れてしまった場合、一番影響が少ないのが `local` だから。