### PR TITLE
DockerでGoの実行環境を作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+node_modules/
+.envrc
+.gitignore
+package.json
+package-lock.json
+serverless.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.15-alpine3.12
+
+LABEL maintainer="https://github.com/nekochans"
+
+WORKDIR /go/app
+
+COPY . .
+
+RUN set -eux && \
+  apk update && \
+  apk add --no-cache git curl make
+
+ENV CGO_ENABLED 0

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ aws_secret_access_key=YOUR_AWS_SECRET_ACCESS_KEY
 
 `npm ci` を実行してpackageをインストールします。
 
+## コンテナの起動
+
+Dockerコンテナを起動します。
+
+テストの実行やLintの実行等は基本的にコンテナ内で実行します。
+
+### 初回
+
+`docker-compose up --build -d`
+
+### 停止
+
+`docker-compose down`
+
+### 停止（関連するイメージ、ボリュームを完全に削除）
+
+`docker-compose down --rmi all --volumes --remove-orphans`
+
 # デプロイ関連のコマンド
 
 ## Build & Deploy
@@ -71,7 +89,11 @@ deployは [Serverless Framework](https://www.serverless.com/) を利用してい
 
 ## テスト実行
 
-`make test`
+`docker-compose exec go sh` でGoのコンテナに入ります。
+
+Goのコンテナ内で `make test` を実行します。
+
+もしくはホストPC上で `docker-compose exec go make test` を実行しても良いです。
 
 ## ソースコードのformat
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  go:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    restart: always
+    command: 'tail -f /dev/null'
+    volumes:
+      - ./:/go/app
+      - exclude:/go/app/node_modules/
+    environment:
+      DEPLOY_STAGE: ${DEPLOY_STAGE}
+      TARGET_USER_POOL_ID: ${TARGET_USER_POOL_ID}
+      TRIGGER_USER_POOL_NAME: ${TRIGGER_USER_POOL_NAME}
+      REGION: ${REGION}
+      KIMONO_APP_FRONTEND_URL: ${KIMONO_APP_FRONTEND_URL}
+volumes:
+  exclude:
+    driver: 'local'


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/kimono-app-cognito-lambda/issues/5

# Doneの定義
- https://github.com/nekochans/kimono-app-cognito-lambda/issues/5 の完了条件を満たしている事

# 変更点概要
- `Dockerfile` と `docker-compose.yml` を追加、 `make test` でテストが実行出来るところまで確認済

# 補足情報
Goのコンテナの中でNode.jsをインストールしたくなかったので、デプロイに関しては https://github.com/nekochans/kimono-app-cognito-lambda/issues/4 でGitHubActions上で実行するようにする予定。